### PR TITLE
:sparkles: Add health check endpoint with associated DTO and versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,10 @@ Esperamos que você ache este projeto útil!
 
 ---
 
+## Swagger
+
+ - [Swagger Local](http://localhost:8080/api/swagger-ui/index.html#/)
+
+---
+
 ### Em construção...

--- a/src/main/java/br/com/diegosneves/tabnewsserver/controller/HealthCheckController.java
+++ b/src/main/java/br/com/diegosneves/tabnewsserver/controller/HealthCheckController.java
@@ -1,0 +1,43 @@
+package br.com.diegosneves.tabnewsserver.controller;
+
+import br.com.diegosneves.tabnewsserver.dto.HealthCheckDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/health")
+@Tag(name = "Health Check")
+public class HealthCheckController {
+
+    private static final String HEALTH_CHECK_STATUS_UP = "UP";
+    private static final String HEALTH_CHECK_OPERATION_SUMMARY = "Health Check";
+    private static final String HEALTH_CHECK_DESCRIPTION = "Verifica o status da aplicação e retorna informações de versão";
+
+    private final String appVersion;
+
+    public HealthCheckController(@Value("${application.version}") String appVersion) {
+        this.appVersion = appVersion;
+    }
+
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = HEALTH_CHECK_OPERATION_SUMMARY, description = HEALTH_CHECK_DESCRIPTION)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Aplicação funcionando normalmente", content = @Content(schema = @Schema(implementation = HealthCheckDTO.class)))
+    })
+    public ResponseEntity<HealthCheckDTO> checkHealth() {
+        final var response = HealthCheckDTO.of(HEALTH_CHECK_STATUS_UP, this.appVersion);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/br/com/diegosneves/tabnewsserver/dto/HealthCheckDTO.java
+++ b/src/main/java/br/com/diegosneves/tabnewsserver/dto/HealthCheckDTO.java
@@ -1,0 +1,19 @@
+package br.com.diegosneves.tabnewsserver.dto;
+
+import java.time.LocalDateTime;
+
+public record HealthCheckDTO(
+        String status,
+        LocalDateTime timestamp,
+        String version
+) {
+
+    public static HealthCheckDTO of(String status, LocalDateTime timestamp, String version) {
+        return new HealthCheckDTO(status, timestamp, version);
+    }
+
+    public static HealthCheckDTO of(String status, String version) {
+        return HealthCheckDTO.of(status, LocalDateTime.now(), version);
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,9 @@ server:
   servlet:
     context-path: /api
 
+application:
+  version: 1.0.0
+
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## Resumo
Este Pull Request adiciona um novo endpoint de verificação de saúde (health check) ao servidor, junto com a implementação do DTO correspondente e configuração de versionamento da aplicação. Também atualiza a documentação, incluindo o link para o Swagger.

### Principais Alterações
- **Adição do HealthCheckController:**
  - Criação de um endpoint `/health` para monitoramento do status da aplicação
  - Implementação de documentação completa com anotações Swagger
  - Configuração para retornar informações sobre a versão e estado atual da aplicação

- **Nova classe DTO para Health Check:**
  - Implementação do `HealthCheckDTO` como um record Java
  - Inclusão de campos para status, timestamp e versão da aplicação
  - Métodos factory para facilitar a criação de instâncias

- **Configuração de Versionamento:**
  - Adição da propriedade `application.version` no arquivo application.yaml
  - Injeção da versão no controller via anotação `@Value`

- **Documentação:**
  - Atualização do README.md para incluir link para a interface Swagger
  - Adição de anotações detalhadas para OpenAPI/Swagger no controller

- **Estrutura do Projeto:**
  - Organização das classes em pacotes apropriados (controller, dto)
  - Integração com a configuração existente do Swagger/OpenAPI