### PR TITLE
:bug: Update branch check in CI workflow to enforce 'develop'

### DIFF
--- a/.github/workflows/ci-hlg.yaml
+++ b/.github/workflows/ci-hlg.yaml
@@ -47,8 +47,8 @@ jobs:
 
       - name: check PR head branch
         run: |
-          if [[ "${{ github.head_ref }}" != release/* ]]; then
-            echo "PRs to main must come from a release/* branch. PR is from '${{ github.head_ref }}'"
+          if [[ "${{ github.head_ref }}" != develop ]]; then
+            echo "PRs to main must come from a develop branch. PR is from '${{ github.head_ref }}'"
             exit 1
           fi
 


### PR DESCRIPTION
The workflow previously allowed only 'release/*' branches for PRs to main. This has been changed to enforce that PRs must originate from the 'develop' branch. The update ensures alignment with the updated branch strategy.